### PR TITLE
Avoid unbounded strcpy() from environment to stack

### DIFF
--- a/protocol.c
+++ b/protocol.c
@@ -62,6 +62,9 @@ dsmesock_connection_t* dsmesock_connect(void)
 
       memset(&c_addr, 0, sizeof(c_addr));
       c_addr.sun_family = AF_UNIX;
+      if (strlen(dsmesock_filename) >= sizeof(c_addr.sun_path)) {
+          return NULL;
+      }
       strcpy(c_addr.sun_path, dsmesock_filename);
 
       if (connect(fd, (struct sockaddr *)&c_addr, sizeof(c_addr)) == -1 ||


### PR DESCRIPTION
If the "`DSME_SOCKFILE`" environment variable is set and has a
length longer than `sizeof(c_addr.sun_path)` ([usually 108 bytes](https://man7.org/linux/man-pages/man7/unix.7.html)),
then `strcpy()` will overwrite values on the stack.

Avoid the issue by checking the string length before copying
it onto the stack, and returning an error if it's too long.

Note that `getenv()` isn't threadsafe, so this assumes that the
environment isn't changed, and it also assumes that the pointer
in `dsmesock_default_location` (as well as the pointed-to data)
isn't changed by another thread between the `strlen()` and the
`strcpy()`. A thread-safe version would most likely involve either
a copy of the string or the use of `strncpy()` (which might result
in a truncated path, which could lead to other bugs/crashes).

Signed-off-by: Thomas Perl <m@thp.io>