### PR TITLE
Do not export dsmesock_default_location as symbol

### DIFF
--- a/include/dsme/protocol.h
+++ b/include/dsme/protocol.h
@@ -147,12 +147,6 @@ void dsmesock_close(dsmesock_connection_t* conn);
 */
 const struct ucred* dsmesock_getucred(dsmesock_connection_t* conn);
 
-
-/**
-   Holds path to dsme socket default location
-*/
-extern const char* dsmesock_default_location;
-
 #ifdef __cplusplus
 };
 #endif

--- a/protocol.c
+++ b/protocol.c
@@ -44,7 +44,7 @@
 
 static GSList* connections = 0;
 
-const char* dsmesock_default_location = "/run/dsme.socket";
+static const char* dsmesock_default_location = "/run/dsme.socket";
 
 dsmesock_connection_t* dsmesock_connect(void)
 {


### PR DESCRIPTION
This avoids a linker issue where `mce` (presumably built with libdsme headers before e457e7a93dd3061767f4537e6b30fbdefaed9944 was merged) exports `dsmesock_default_location` (zero-initialized in `.bss`) via the dynamic linker and that "wins" over the one declared (and initialized to `"/run/dsme.socket"`) in libdsme:

https://twitter.com/thp4/status/1409206475227119619
https://blog.mlich.cz/2021/06/mce-debugging/

This changes the ABI (`dsmesock_default_location` isn't exported anymore), but I assume that nothing depending on `libdsme` would read or even modify that value (if there is a valid use case for accessing this variable as a library user, it better be done via a getter and/or setter method).